### PR TITLE
Remove redundant CMD line

### DIFF
--- a/aws-nginx-ubuntu-simple/Dockerfile-simple-apache
+++ b/aws-nginx-ubuntu-simple/Dockerfile-simple-apache
@@ -6,5 +6,4 @@ RUN     apt-get -y install php5 libapache2-mod-php5 php5-mcrypt
 RUN     sed -e "s/DirectoryIndex/DirectoryIndex index.php/" < /etc/apache2/mods-enabled/dir.conf > /tmp/foo.sed
 RUN     mv /tmp/foo.sed /etc/apache2/mods-enabled/dir.conf
 ADD     example/index.php /var/www/html/
-CMD     ["rm -f /var/run/apache2/apache2.pid" ]
 CMD     ["/usr/sbin/apache2ctl", "-D FOREGROUND" ]

--- a/nginx-ubuntu-simple/Dockerfile-simple-apache
+++ b/nginx-ubuntu-simple/Dockerfile-simple-apache
@@ -6,5 +6,4 @@ RUN     apt-get -y install php5 libapache2-mod-php5 php5-mcrypt
 RUN     sed -e "s/DirectoryIndex/DirectoryIndex index.php/" < /etc/apache2/mods-enabled/dir.conf > /tmp/foo.sed
 RUN     mv /tmp/foo.sed /etc/apache2/mods-enabled/dir.conf
 ADD     example/index.php /var/www/html/
-CMD     ["rm -f /var/run/apache2/apache2.pid" ]
 CMD     ["/usr/sbin/apache2ctl", "-D FOREGROUND" ]


### PR DESCRIPTION
If you specify several CMD lines in a Dockerfile, only the last one is taken as the command to run.  So I removed the unused one.
